### PR TITLE
Fix listen() call for Linux kernel v4.4+

### DIFF
--- a/XAPP1251/src/xvcServer.c
+++ b/XAPP1251/src/xvcServer.c
@@ -248,7 +248,7 @@ int main(int argc, char **argv) {
       return 1;
    }
 
-   if (listen(s, 0) < 0) {
+   if (listen(s, 1) < 0) {
       perror("listen");
       return 1;
    }


### PR DESCRIPTION
Without this change, no connections are accepted when running kernel
v4.4 or later. Connections are dropped with the following message:

 TCP: request_sock_TCP: Possible SYN flooding on port 2542. Dropping request.

This is due to a modification how the listen's backlog parameter works.
The kernel commit in suspect is ef547f2ac16bd9d77a780a0e7c70857e69e8f23f.

Similar stories:
- https://ldpreload.com/blog/git-bisect-run
- https://github.com/bitshares/websocketpp/commit/e6c4e3c54bf9cf1892c85a6ed6289486bba36fa1