### PR TITLE
Multidevice xvc server

### DIFF
--- a/src/user/verify_xilinx_xvc_driver.c
+++ b/src/user/verify_xilinx_xvc_driver.c
@@ -35,8 +35,6 @@
 
 #include "xvc_ioctl.h"
 
-static const char char_path[] = "/dev/xilinx_xvc_driver";
-
 #define BYTE_ALIGN(a) ((a + 7) / 8)
 #define MIN(a, b) (a < b ? a : b)
 #define MAX(a, b) (a > b ? a : b)
@@ -157,11 +155,17 @@ int main(int argc, char **argv)
     unsigned test_lens[] = {32, 0};
     unsigned test_index = 0;
 
+    if (argc < 2)
+    {
+      fprintf(stderr, "Error: supply the device name as an argument\n");
+      return -1;
+    }
+
     // try opening the driver
-    fd = open(char_path, O_RDWR | O_SYNC);
+    fd = open(argv[1], O_RDWR | O_SYNC);
     if (fd <= 0)
     {
-        printf("Could not open driver at %s\n", char_path);
+        printf("Could not open driver at %s\n", argv[1]);
         printf("Error: %s\n", strerror(errno));
         return 0;
     }

--- a/src/user/xvcServer.c
+++ b/src/user/xvcServer.c
@@ -213,7 +213,6 @@ void display_driver_properties(int fd_ioctl) {
         return;
     }
 
-    printf("INFO: XVC driver character file: %s\n", CHAR_DEV_PATH);
     printf("INFO: debug_bridge base address: 0x%lX\n", props.debug_bridge_base_addr);
     printf("INFO: debug_bridge size: 0x%lX\n", props.debug_bridge_size);
     printf("INFO: debug_bridge device tree compatibility string: %s\n\n", props.debug_bridge_compat_string);
@@ -234,6 +233,7 @@ int main(int argc, char **argv) {
         switch (c) {
             case 'v':
                 verbose = 1;
+                printf("Enable verbose mode\n");
                 break;
             case '?':
                 fprintf(stderr, "usage: %s [-v] device_node\n", *argv);
@@ -291,7 +291,10 @@ int main(int argc, char **argv) {
         return 1;
     }
 
-    printf("INFO: To connect to this xvcServer instance, use url: TCP:%s:%u\n\n", hostname, XVC_PORT);
+    printf("INFO: To connect to this xvcServer instance, use url: %s:%u\n", hostname, XVC_PORT);
+    printf("INFO: e.g. tcl:\n");
+    printf("connect_hw_server -url localhost:3121 -allow_non_jtag\n");
+    printf("open_hw_target -xvc_url %s:%u\n\n", hostname, XVC_PORT);
 
     fd_set conn;
     int maxfd = 0;

--- a/src/user/xvcServer.c
+++ b/src/user/xvcServer.c
@@ -42,7 +42,7 @@ static int verbose = 0;
 #define XVC_PORT 2542
 
 static int sread(int fd, void *target, int len) {
-    unsigned char *t = target;
+    unsigned char *t = (unsigned char*)target;
     while (len) {
         int r = read(fd, t, len);
         if (r <= 0)
@@ -72,10 +72,11 @@ int handle_data(int fd, int fd_ioctl) {
             return 1;
 
         if (memcmp(cmd, "ge", 2) == 0) {
+            int len = strlen(xvcInfo);
             if (sread(fd, cmd, 6) != 1)
                 return 1;
-            memcpy(result, xvcInfo, strlen(xvcInfo));
-            if (write(fd, result, strlen(xvcInfo)) != strlen(xvcInfo)) {
+            memcpy(result, xvcInfo, len);
+            if (write(fd, result, len) != len) {
                 perror("write");
                 return 1;
             }
@@ -114,7 +115,7 @@ int handle_data(int fd, int fd_ioctl) {
             return 1;
         }
 
-        int nr_bytes = (len + 7) / 8;
+        unsigned int nr_bytes = (len + 7) / 8;
         if (nr_bytes * 2 > sizeof(buffer)) {
             fprintf(stderr, "buffer size exceeded\n");
             return 1;
@@ -192,7 +193,7 @@ int handle_data(int fd, int fd_ioctl) {
             return errsv;
         }
 #endif /* !USE_IOCTL */
-        if (write(fd, result, nr_bytes) != nr_bytes) {
+        if (write(fd, result, nr_bytes) != (int)nr_bytes) {
             perror("write");
             return 1;
         }

--- a/src/user/xvcServer.c
+++ b/src/user/xvcServer.c
@@ -59,7 +59,7 @@ int handle_data(int fd, volatile jtag_t* ptr) {
 int handle_data(int fd, int fd_ioctl) {
 #endif /* !USE_IOCTL */
     char xvcInfo[32];
-    unsigned int bufferSize = 2048;
+    unsigned int bufferSize = 4096;
 
     sprintf(xvcInfo, "xvcServer_v1.0:%u\n", bufferSize);
 
@@ -147,7 +147,7 @@ int handle_data(int fd, int fd_ioctl) {
             tdi = 0;
             tdo = 0;
 
-            if (bytesLeft < 4) {
+            if (bytesLeft <= 4) {
                 shift_num_bits = bitsLeft;
             }
             shift_num_bytes = (shift_num_bits + 7) / 8;

--- a/src/user/xvcServer.c
+++ b/src/user/xvcServer.c
@@ -81,7 +81,7 @@ int handle_data(int fd, int fd_ioctl) {
                 return 1;
             }
             if (verbose) {
-                printf("%u : Received command: 'getinfo'\n", (int)time(NULL));
+                printf("%u : Received command: 'getinfo'", (int)time(NULL));
                 printf("\t Replied with %s\n", xvcInfo);
             }
             break;
@@ -94,7 +94,7 @@ int handle_data(int fd, int fd_ioctl) {
                 return 1;
             }
             if (verbose) {
-                printf("%u : Received command: 'settck'\n", (int)time(NULL));
+                printf("%u : Received command: 'settck'", (int)time(NULL));
                 printf("\t Replied with '%.*s'\n\n", 4, cmd + 5);
             }
             break;
@@ -102,7 +102,7 @@ int handle_data(int fd, int fd_ioctl) {
             if (sread(fd, cmd, 4) != 1)
                 return 1;
             if (verbose) {
-                printf("%u : Received command: 'shift'\n", (int)time(NULL));
+                printf("%u : Received command: 'shift'\t", (int)time(NULL));
             }
         } else {
             fprintf(stderr, "invalid cmd '%s'\n", cmd);
@@ -128,9 +128,8 @@ int handle_data(int fd, int fd_ioctl) {
         memset(result, 0, nr_bytes);
 
         if (verbose) {
-            printf("\tNumber of Bits  : %d\n", len);
+            printf("\tNumber of Bits  : %d\t", len);
             printf("\tNumber of Bytes : %d \n", nr_bytes);
-            printf("\n");
         }
 
 #ifndef USE_IOCTL
@@ -172,10 +171,11 @@ int handle_data(int fd, int fd_ioctl) {
             byteIndex += shift_num_bytes;
 
             if (verbose) {
-                printf("LEN : 0x%08x\n", shift_num_bits);
-                printf("TMS : 0x%08x\n", tms);
-                printf("TDI : 0x%08x\n", tdi);
-                printf("TDO : 0x%08x\n", tdo);
+		int mask = (1 << shift_num_bits) - 1;
+                printf("LEN : %8d\t", shift_num_bits);
+                printf("TMS : 0x%08x\t", tms);
+                printf("TDI : 0x%08x\t", tdi);
+                printf("TDO : 0x%08x\n", tdo & mask);
             }
         }
 #else /* USE_IOCTL */
@@ -196,6 +196,10 @@ int handle_data(int fd, int fd_ioctl) {
         if (write(fd, result, nr_bytes) != (int)nr_bytes) {
             perror("write");
             return 1;
+        }
+
+        if (verbose) {
+            printf("\n");
         }
     } while (1);
 

--- a/src/user/xvcServer.c
+++ b/src/user/xvcServer.c
@@ -280,7 +280,7 @@ int main(int argc, char **argv) {
         return 1;
     }
 
-    if (listen(s, 0) < 0) {
+    if (listen(s, 1) < 0) {
         perror("listen");
         return 1;
     }


### PR DESCRIPTION
Fixed some bugs (listen() and shiften len > 18 & <32)
Pass device node as an argument (in case there are multiple jtag interfaces)
Print the tcl command necessary to open the hardware server.