### PR TITLE
Fix XVC driver ZynqMP build for Linux kernel v6.x

### DIFF
--- a/zynqMP/src/driver/xvc_driver.c
+++ b/zynqMP/src/driver/xvc_driver.c
@@ -21,12 +21,11 @@
 #include <linux/fs.h>
 #include <linux/cdev.h>
 #include <linux/slab.h>
-#include <asm/uaccess.h>
 #include <linux/spinlock.h>
 #include <linux/platform_device.h>
 #include <linux/list.h>
 #include <linux/uaccess.h>
-#include <asm-generic/io.h>
+#include <linux/io.h>
 
 #include "xvc_driver.h"
 

--- a/zynqMP/src/driver/xvc_driver_base.c
+++ b/zynqMP/src/driver/xvc_driver_base.c
@@ -27,7 +27,7 @@
 #include <linux/platform_device.h>
 #include <linux/kernel.h>
 #include <linux/version.h>
-#include <asm/io.h>
+#include <linux/io.h>
 #include <linux/mod_devicetable.h>
 
 #include "xvc_driver.h"
@@ -165,7 +165,7 @@ int probe(struct platform_device* pdev) {
 			}
 
 #ifndef GET_DB_BY_RES
-			db_ptrs[i] = ioremap_nocache(db_addr, db_size);
+			db_ptrs[i] = ioremap(db_addr, db_size);
 #else
 			db_res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
 			if (db_res) {


### PR DESCRIPTION
Fix deprecated includes and function in XVC driver source to able to build in Linux kernel v6.x. Build was tested in Petalinux 2023.1 Yocto project.

It can solve issue: https://github.com/Xilinx/XilinxVirtualCable/issues/15