### PR TITLE
Fix string buffer overflow in xvcServer for Zynq 7000

### DIFF
--- a/jtag/zynq7000/XAPP1251/src/xvcServer.c
+++ b/jtag/zynq7000/XAPP1251/src/xvcServer.c
@@ -208,7 +208,7 @@ int main(int argc, char **argv) {
    char *d = "uio0";
    int fd_uio;
    int port = 2542;
-   char dev_file[]="/dev/";
+   char dev_file[20]="/dev/";
    
    struct sockaddr_in address;
    


### PR DESCRIPTION
Running the xvcServer on the Zynq 7000 results in a buffer overflow error. Extending the dev_file character buffer to allow room for string concatenation resolves the error.