### PR TITLE
Make CROSS_COMPILE overrideable for external build systems (Fix Yocto build)

### DIFF
--- a/jtag/zynqMP/src/driver/Makefile
+++ b/jtag/zynqMP/src/driver/Makefile
@@ -1,6 +1,6 @@
 DRIVER := xilinx_xvc_driver
-export CROSS_COMPILE := aarch64-linux-gnu-
-export ARCH := arm64
+export CROSS_COMPILE ?= aarch64-linux-gnu-
+export ARCH ?= arm64
 
 ccflags-y := -DLOG_PREFIX=\"$(DRIVER):\ \"
 $(DRIVER)-y := \

--- a/jtag/zynqMP/src/user/Makefile
+++ b/jtag/zynqMP/src/user/Makefile
@@ -1,5 +1,5 @@
-export CROSS_COMPILE := aarch64-linux-gnu-
-export ARCH := arm64
+export CROSS_COMPILE ?= aarch64-linux-gnu-
+export ARCH ?= arm64
 MYCC := $(CROSS_COMPILE)gcc
 
 DRIVER := xilinx_xvc_driver


### PR DESCRIPTION
Note that Yocto (langdale) uses `CROSS_COMPILE=aarch64-xilinx-linux-`, the hardcoded `CROSS_COMPILE` breaks the build.